### PR TITLE
Enable Draft4 "type" keyword

### DIFF
--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -17,9 +17,9 @@
     <PackageReleaseNotes>Release notes can be found at https://github.com/gregsdennis/Graeae</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>Graeae.Models.xml</DocumentationFile>
-    <Version>0.2.0</Version>
-    <FileVersion>0.2.0.0</FileVersion>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
+    <Version>0.2.1</Version>
+    <FileVersion>0.2.1.0</FileVersion>
+    <AssemblyVersion>0.2.1.0</AssemblyVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -179,6 +179,7 @@ public static class Draft4Support
 		SchemaKeywordRegistry.Register<Draft4ExclusiveMinimumKeyword>();
 		SchemaKeywordRegistry.Register<Draft4IdKeyword>();
 		SchemaKeywordRegistry.Register<NullableKeyword>();
+		SchemaKeywordRegistry.Register<Draft4TypeKeyword>();
 
 		SchemaRegistry.Global.Register(Draft4MetaSchema);
 	}


### PR DESCRIPTION
Models with "nullable" were failing to validate against OpenAPI 3.0 schemas because the standard "type" keyword was being used. Aded the `Draft4TypeKeyword` to `SchemaKeywordRegistry` in `Draft4Support.Enable()`.