### PR TITLE
Update dependencies

### DIFF
--- a/Graeae.Models/Example.cs
+++ b/Graeae.Models/Example.cs
@@ -92,7 +92,7 @@ public class Example : IRefTargetContainer
 		{
 			obj.MaybeAdd("summary", example.Summary);
 			obj.MaybeAdd("description", example.Description);
-			obj.MaybeAdd("value", example.Value.DeepClone());
+			obj.MaybeAdd("value", example.Value?.DeepClone());
 			obj.MaybeAdd("externalValue", example.ExternalValue);
 			obj.AddExtensions(example.ExtensionData);
 		}

--- a/Graeae.Models/Example.cs
+++ b/Graeae.Models/Example.cs
@@ -92,7 +92,7 @@ public class Example : IRefTargetContainer
 		{
 			obj.MaybeAdd("summary", example.Summary);
 			obj.MaybeAdd("description", example.Description);
-			obj.MaybeAdd("value", example.Value.Copy());
+			obj.MaybeAdd("value", example.Value.DeepClone());
 			obj.MaybeAdd("externalValue", example.ExternalValue);
 			obj.AddExtensions(example.ExtensionData);
 		}

--- a/Graeae.Models/Example.cs
+++ b/Graeae.Models/Example.cs
@@ -71,7 +71,7 @@ public class Example : IRefTargetContainer
 	{
 		Summary = obj.MaybeString("summary", "example");
 		Description = obj.MaybeString("description", "example");
-		Value = obj.TryGetPropertyValue("value", out var v) ? v ?? JsonNull.SignalNode : null;
+		Value = obj.TryGetPropertyValue("value", out var v) ? v : null;
 		ExternalValue = obj.MaybeString("externalValue", "example");
 		ExtensionData = ExtensionData.FromNode(obj);
 	}

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -45,9 +45,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="5.1.3" />
-    <PackageReference Include="JsonSchema.Net.OpenApi" Version="2.0.0" />
-    <PackageReference Include="Yaml2JsonNode" Version="1.2.4" />
+    <PackageReference Include="JsonSchema.Net" Version="7.1.0" />
+    <PackageReference Include="JsonSchema.Net.OpenApi" Version="3.1.0" />
+    <PackageReference Include="Yaml2JsonNode" Version="2.1.0" />
   </ItemGroup>
 
 </Project>

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -45,7 +45,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JsonSchema.Net" Version="7.1.0" />
+    <PackageReference Include="JsonSchema.Net" Version="7.1.1" />
     <PackageReference Include="JsonSchema.Net.OpenApi" Version="3.1.0" />
     <PackageReference Include="Yaml2JsonNode" Version="2.1.0" />
   </ItemGroup>

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -17,9 +17,9 @@
     <PackageReleaseNotes>Release notes can be found at https://github.com/gregsdennis/Graeae</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>Graeae.Models.xml</DocumentationFile>
-    <Version>0.2.1</Version>
-    <FileVersion>0.2.1.0</FileVersion>
-    <AssemblyVersion>0.2.1.0</AssemblyVersion>
+    <Version>3.0.0</Version>
+    <FileVersion>0.3.0.0</FileVersion>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -17,7 +17,7 @@
     <PackageReleaseNotes>Release notes can be found at https://github.com/gregsdennis/Graeae</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>Graeae.Models.xml</DocumentationFile>
-    <Version>3.0.0</Version>
+    <Version>0.3.0</Version>
     <FileVersion>0.3.0.0</FileVersion>
     <AssemblyVersion>0.3.0.0</AssemblyVersion>
     <IncludeSymbols>true</IncludeSymbols>

--- a/Graeae.Models/Graeae.Models.xml
+++ b/Graeae.Models/Graeae.Models.xml
@@ -1799,6 +1799,11 @@
             Defines the source generated JSON serialization contract metadata for a given type.
             </summary>
         </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.SchemaValueType">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
         <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Default">
             <summary>
             The default <see cref="T:System.Text.Json.Serialization.JsonSerializerContext"/> associated with a default <see cref="T:System.Text.Json.JsonSerializerOptions"/> instance.

--- a/Graeae.Models/Graeae.Models.xml
+++ b/Graeae.Models/Graeae.Models.xml
@@ -1691,7 +1691,7 @@
             </summary>
             <param name="value">The minimum value.</param>
         </member>
-        <member name="M:Graeae.Models.SchemaDraft4.Draft4ExclusiveMaximumKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.Collections.Generic.IReadOnlyList{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4ExclusiveMaximumKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.ReadOnlySpan{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
             <summary>Builds a constraint object for a keyword.</summary>
             <param name="schemaConstraint">The <see cref="T:Json.Schema.SchemaConstraint" /> for the schema object that houses this keyword.</param>
             <param name="localConstraints">
@@ -1733,7 +1733,7 @@
             </summary>
             <param name="value">The minimum value.</param>
         </member>
-        <member name="M:Graeae.Models.SchemaDraft4.Draft4ExclusiveMinimumKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.Collections.Generic.IReadOnlyList{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4ExclusiveMinimumKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.ReadOnlySpan{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
             <summary>Builds a constraint object for a keyword.</summary>
             <param name="schemaConstraint">The <see cref="T:Json.Schema.SchemaConstraint" /> for the schema object that houses this keyword.</param>
             <param name="localConstraints">
@@ -1764,7 +1764,7 @@
             </summary>
             <param name="id">The ID.</param>
         </member>
-        <member name="M:Graeae.Models.SchemaDraft4.Draft4IdKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.Collections.Generic.IReadOnlyList{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4IdKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.ReadOnlySpan{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
             <summary>Builds a constraint object for a keyword.</summary>
             <param name="schemaConstraint">The <see cref="T:Json.Schema.SchemaConstraint" /> for the schema object that houses this keyword.</param>
             <param name="localConstraints">
@@ -1825,7 +1825,7 @@
             </summary>
             <param name="type">The instance type that is allowed.</param>
         </member>
-        <member name="M:Graeae.Models.SchemaDraft4.Draft4TypeKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.Collections.Generic.IReadOnlyList{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4TypeKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.ReadOnlySpan{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
             <summary>Builds a constraint object for a keyword.</summary>
             <param name="schemaConstraint">The <see cref="T:Json.Schema.SchemaConstraint" /> for the schema object that houses this keyword.</param>
             <param name="localConstraints">
@@ -1909,7 +1909,7 @@
             </summary>
             <param name="value">Whether the `minimum` value should be considered exclusive.</param>
         </member>
-        <member name="M:Graeae.Models.SchemaDraft4.NullableKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.Collections.Generic.IReadOnlyList{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
+        <member name="M:Graeae.Models.SchemaDraft4.NullableKeyword.GetConstraint(Json.Schema.SchemaConstraint,System.ReadOnlySpan{Json.Schema.KeywordConstraint},Json.Schema.EvaluationContext)">
             <summary>Builds a constraint object for a keyword.</summary>
             <param name="schemaConstraint">The <see cref="T:Json.Schema.SchemaConstraint" /> for the schema object that houses this keyword.</param>
             <param name="localConstraints">

--- a/Graeae.Models/Graeae.Models.xml
+++ b/Graeae.Models/Graeae.Models.xml
@@ -1774,6 +1774,50 @@
             <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
             <returns>A constraint object.</returns>
         </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Draft4ExclusiveMaximumKeyword">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Draft4ExclusiveMinimumKeyword">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Draft4IdKeyword">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Draft4TypeKeyword">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.NullableKeyword">
+            <summary>
+            Defines the source generated JSON serialization contract metadata for a given type.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.Default">
+            <summary>
+            The default <see cref="T:System.Text.Json.Serialization.JsonSerializerContext"/> associated with a default <see cref="T:System.Text.Json.JsonSerializerOptions"/> instance.
+            </summary>
+        </member>
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.GeneratedSerializerOptions">
+            <summary>
+            The source-generated options associated with this context.
+            </summary>
+        </member>
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.#ctor">
+            <inheritdoc/>
+        </member>
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.#ctor(System.Text.Json.JsonSerializerOptions)">
+            <inheritdoc/>
+        </member>
+        <member name="M:Graeae.Models.SchemaDraft4.Draft4SchemaSerializerContext.GetTypeInfo(System.Type)">
+            <inheritdoc/>
+        </member>
         <member name="T:Graeae.Models.SchemaDraft4.Draft4Support">
             <summary>
             Provides additional functionality for JSON Schema draft 4 support.

--- a/Graeae.Models/Graeae.Models.xml
+++ b/Graeae.Models/Graeae.Models.xml
@@ -1794,7 +1794,7 @@
             Defines the JSON Schema draft 4 meta-schema URI.
             </summary>
         </member>
-        <member name="F:Graeae.Models.SchemaDraft4.Draft4Support.Draft4MetaSchema">
+        <member name="P:Graeae.Models.SchemaDraft4.Draft4Support.Draft4MetaSchema">
             <summary>
             Defines the JSON Schema draft 4 meta-schema.
             </summary>

--- a/Graeae.Models/Header.cs
+++ b/Graeae.Models/Header.cs
@@ -141,7 +141,7 @@ public class Header : IRefTargetContainer
 			obj.MaybeAdd("explode", header.Explode);
 			obj.MaybeAdd("allowReserved", header.AllowReserved);
 			obj.MaybeSerialize("schema", header.Schema, options);
-			obj.MaybeAdd("example", header.Example.Copy());
+			obj.MaybeAdd("example", header.Example.DeepClone());
 			obj.MaybeAddMap("examples", header.Examples, Models.Example.ToNode);
 			obj.MaybeAddMap("content", header.Content, x => MediaType.ToNode(x, options));
 			obj.AddExtensions(header.ExtensionData);

--- a/Graeae.Models/Header.cs
+++ b/Graeae.Models/Header.cs
@@ -141,7 +141,7 @@ public class Header : IRefTargetContainer
 			obj.MaybeAdd("explode", header.Explode);
 			obj.MaybeAdd("allowReserved", header.AllowReserved);
 			obj.MaybeSerialize("schema", header.Schema, options);
-			obj.MaybeAdd("example", header.Example.DeepClone());
+			obj.MaybeAdd("example", header.Example?.DeepClone());
 			obj.MaybeAddMap("examples", header.Examples, Models.Example.ToNode);
 			obj.MaybeAddMap("content", header.Content, x => MediaType.ToNode(x, options));
 			obj.AddExtensions(header.ExtensionData);

--- a/Graeae.Models/Header.cs
+++ b/Graeae.Models/Header.cs
@@ -113,7 +113,7 @@ public class Header : IRefTargetContainer
 		Explode = obj.MaybeBool("explode", "header");
 		AllowReserved = obj.MaybeBool("allowReserved", "header");
 		Schema = obj.MaybeDeserialize<JsonSchema>("schema");
-		Example = obj.TryGetPropertyValue("example", out var v) ? v ?? JsonNull.SignalNode : null;
+		Example = obj.TryGetPropertyValue("example", out var v) ? v : null;
 		Examples = obj.MaybeMap("examples", Models.Example.FromNode);
 		Content = obj.MaybeMap("content", MediaType.FromNode);
 		ExtensionData = ExtensionData.FromNode(obj);

--- a/Graeae.Models/MediaType.cs
+++ b/Graeae.Models/MediaType.cs
@@ -49,7 +49,7 @@ public class MediaType : IRefTargetContainer
 		var mediaType = new MediaType
 		{
 			Schema = obj.MaybeDeserialize<JsonSchema>("schema"),
-			Example = obj.TryGetPropertyValue("example", out var v) ? v ?? JsonNull.SignalNode : null,
+			Example = obj.TryGetPropertyValue("example", out var v) ? v : null,
 			Examples = obj.MaybeMap("examples", Models.Example.FromNode),
 			Encoding = obj.MaybeMap("encoding", Models.Encoding.FromNode),
 			ExtensionData = ExtensionData.FromNode(obj)

--- a/Graeae.Models/MediaType.cs
+++ b/Graeae.Models/MediaType.cs
@@ -67,7 +67,7 @@ public class MediaType : IRefTargetContainer
 		var obj = new JsonObject();
 
 		obj.MaybeSerialize("schema", mediaType.Schema, options);
-		obj.MaybeAdd("example", mediaType.Example.DeepClone());
+		obj.MaybeAdd("example", mediaType.Example?.DeepClone());
 		obj.MaybeAddMap("examples", mediaType.Examples, Models.Example.ToNode);
 		obj.MaybeAddMap("encoding", mediaType.Encoding, x => Models.Encoding.ToNode(x, options));
 		obj.AddExtensions(mediaType.ExtensionData);

--- a/Graeae.Models/MediaType.cs
+++ b/Graeae.Models/MediaType.cs
@@ -67,7 +67,7 @@ public class MediaType : IRefTargetContainer
 		var obj = new JsonObject();
 
 		obj.MaybeSerialize("schema", mediaType.Schema, options);
-		obj.MaybeAdd("example", mediaType.Example.Copy());
+		obj.MaybeAdd("example", mediaType.Example.DeepClone());
 		obj.MaybeAddMap("examples", mediaType.Examples, Models.Example.ToNode);
 		obj.MaybeAddMap("encoding", mediaType.Encoding, x => Models.Encoding.ToNode(x, options));
 		obj.AddExtensions(mediaType.ExtensionData);

--- a/Graeae.Models/OpenApiDocument.cs
+++ b/Graeae.Models/OpenApiDocument.cs
@@ -94,7 +94,7 @@ public class OpenApiDocument : IBaseDocument
 		Json.Schema.Formats.Register(Formats.Int64);
 		Json.Schema.Formats.Register(Formats.Password);
 
-		VocabularyRegistry.Global.Register(Vocabularies.OpenApi);
+		VocabularyRegistry.Register(Vocabularies.OpenApi);
 	}
 
 	/// <summary>

--- a/Graeae.Models/OpenApiDocument.cs
+++ b/Graeae.Models/OpenApiDocument.cs
@@ -224,7 +224,7 @@ public class OpenApiDocument : IBaseDocument
 	{
 		if (!_lookup.TryGetValue(pointer, out var val))
 		{
-			var keys = pointer.Segments.Select(x => x.Value).ToArray();
+			var keys = pointer.ToArray();
 
 			val = PerformLookup(keys) as T;
 			if (val != null)

--- a/Graeae.Models/Parameter.cs
+++ b/Graeae.Models/Parameter.cs
@@ -168,7 +168,7 @@ public class Parameter : IRefTargetContainer
 			obj.MaybeAdd("explode", parameter.Explode);
 			obj.MaybeAdd("allowReserved", parameter.AllowReserved);
 			obj.MaybeSerialize("schema", parameter.Schema, options);
-			obj.MaybeAdd("example", parameter.Example.DeepClone());
+			obj.MaybeAdd("example", parameter.Example?.DeepClone());
 			obj.MaybeAddMap("examples", parameter.Examples, Models.Example.ToNode);
 			obj.MaybeAddMap("content", parameter.Content, x => MediaType.ToNode(x, options));
 			obj.AddExtensions(parameter.ExtensionData);

--- a/Graeae.Models/Parameter.cs
+++ b/Graeae.Models/Parameter.cs
@@ -168,7 +168,7 @@ public class Parameter : IRefTargetContainer
 			obj.MaybeAdd("explode", parameter.Explode);
 			obj.MaybeAdd("allowReserved", parameter.AllowReserved);
 			obj.MaybeSerialize("schema", parameter.Schema, options);
-			obj.MaybeAdd("example", parameter.Example.Copy());
+			obj.MaybeAdd("example", parameter.Example.DeepClone());
 			obj.MaybeAddMap("examples", parameter.Examples, Models.Example.ToNode);
 			obj.MaybeAddMap("content", parameter.Content, x => MediaType.ToNode(x, options));
 			obj.AddExtensions(parameter.ExtensionData);

--- a/Graeae.Models/Parameter.cs
+++ b/Graeae.Models/Parameter.cs
@@ -138,7 +138,7 @@ public class Parameter : IRefTargetContainer
 		Explode = obj.MaybeBool("explode", "parameter");
 		AllowReserved = obj.MaybeBool("allowReserved", "parameter");
 		Schema = obj.MaybeDeserialize<JsonSchema>("schema");
-		Example = obj.TryGetPropertyValue("example", out var v) ? v ?? JsonNull.SignalNode : null;
+		Example = obj.TryGetPropertyValue("example", out var v) ? v : null;
 		Examples = obj.MaybeMap("examples", Models.Example.FromNode);
 		Content = obj.MaybeMap("content", MediaType.FromNode);
 		ExtensionData = ExtensionData.FromNode(obj);

--- a/Graeae.Models/PathTemplate.cs
+++ b/Graeae.Models/PathTemplate.cs
@@ -32,7 +32,7 @@ public class PathTemplate : IEquatable<PathTemplate>, IEquatable<string>
 	{
 		var asPointer = JsonPointer.Parse(source);
 
-		return new PathTemplate(asPointer.Segments.Select(x => x.Value).ToArray());
+		return new PathTemplate(asPointer.ToArray());
 	}
 
 	/// <summary>
@@ -45,7 +45,7 @@ public class PathTemplate : IEquatable<PathTemplate>, IEquatable<string>
 	{
 		var asPointer = JsonPointer.Parse(source);
 
-		template = new PathTemplate(asPointer.Segments.Select(x => x.Value).ToArray());
+		template = new PathTemplate(asPointer.ToArray());
 
 		return true;
 	}

--- a/Graeae.Models/Ref.cs
+++ b/Graeae.Models/Ref.cs
@@ -133,7 +133,7 @@ public static class Ref
 
 	internal static JsonPointer ToPointer(this Span<string> segments)
 	{
-		return JsonPointer.Create(segments.ToArray().Select(x => (PointerSegment)x));
+		return JsonPointer.Create(segments.ToArray().Select(x => (PointerSegment)x).ToArray());
 	}
 
 	internal static async Task<bool> Resolve<T>(OpenApiDocument root, Uri targetUri, Func<JsonNode?, bool> import, Action<T> copy)

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
@@ -58,13 +58,13 @@ public class Draft4ExclusiveMaximumKeyword : IJsonSchemaKeyword
 	/// </param>
 	/// <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
 	/// <returns>A constraint object.</returns>
-	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, IReadOnlyList<KeywordConstraint> localConstraints, EvaluationContext context)
+	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
 		if (BoolValue.HasValue)
 		{
 			if (!BoolValue.Value) return KeywordConstraint.Skip;
 
-			var maximumConstraint = localConstraints.SingleOrDefault(x => x.Keyword == MaximumKeyword.Name);
+			var maximumConstraint = localConstraints.GetKeywordConstraint<MaximumKeyword>();
 			if (maximumConstraint == null) return KeywordConstraint.Skip;
 
 			var value = schemaConstraint.LocalSchema.GetMaximum()!.Value;

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
@@ -88,12 +88,12 @@ public class Draft4ExclusiveMaximumKeyword : IJsonSchemaKeyword
 			return;
 		}
 
-		var number = evaluation.LocalInstance!.AsValue().GetNumber();
+		var number = evaluation.LocalInstance!.AsValue().GetNumber()!.Value;
 
 		if (number >= limit)
 			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMaximum(context.Options.Culture)
 				.ReplaceToken("received", number)
-				.ReplaceToken("limit", BoolValue));
+				.ReplaceToken("limit", BoolValue!.Value));
 	}
 }
 

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Json.More;
 using Json.Schema;
+using Vocabularies = Json.Schema.OpenApi.Vocabularies;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -11,6 +12,7 @@ namespace Graeae.Models.SchemaDraft4;
 [SchemaKeyword(Name)]
 [SchemaSpecVersion(Draft4Support.Draft4Version)]
 [SchemaSpecVersion(SpecVersion.Draft202012)]
+[Vocabulary(Vocabularies.OpenApiId)]
 [DependsOnAnnotationsFrom(typeof(MinimumKeyword))]
 [JsonConverter(typeof(Draft4ExclusiveMaximumKeywordJsonConverter))]
 public class Draft4ExclusiveMaximumKeyword : IJsonSchemaKeyword

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
@@ -95,7 +95,7 @@ public class Draft4ExclusiveMaximumKeyword : IJsonSchemaKeyword
 	}
 }
 
-internal class Draft4ExclusiveMaximumKeywordJsonConverter : JsonConverter<Draft4ExclusiveMaximumKeyword>
+internal class Draft4ExclusiveMaximumKeywordJsonConverter : WeaklyTypedJsonConverter<Draft4ExclusiveMaximumKeyword>
 {
 	public override Draft4ExclusiveMaximumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMaximumKeyword.cs
@@ -89,7 +89,9 @@ public class Draft4ExclusiveMaximumKeyword : IJsonSchemaKeyword
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 
 		if (number >= limit)
-			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMaximum(context.Options.Culture), ("received", number), ("limit", BoolValue));
+			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMaximum(context.Options.Culture)
+				.ReplaceToken("received", number)
+				.ReplaceToken("limit", BoolValue));
 	}
 }
 

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
@@ -87,12 +87,12 @@ public class Draft4ExclusiveMinimumKeyword : IJsonSchemaKeyword
 			return;
 		}
 
-		var number = evaluation.LocalInstance!.AsValue().GetNumber();
+		var number = evaluation.LocalInstance!.AsValue().GetNumber()!.Value;
 
 		if (number >= limit)
 			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMinimum(context.Options.Culture)
 				.ReplaceToken("received", number)
-				.ReplaceToken("limit", BoolValue));
+				.ReplaceToken("limit", BoolValue!.Value));
 	}
 }
 

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
@@ -94,7 +94,7 @@ public class Draft4ExclusiveMinimumKeyword : IJsonSchemaKeyword
 	}
 }
 
-internal class Draft4ExclusiveMinimumKeywordJsonConverter : JsonConverter<Draft4ExclusiveMinimumKeyword>
+internal class Draft4ExclusiveMinimumKeywordJsonConverter : WeaklyTypedJsonConverter<Draft4ExclusiveMinimumKeyword>
 {
 	public override Draft4ExclusiveMinimumKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
@@ -57,13 +57,13 @@ public class Draft4ExclusiveMinimumKeyword : IJsonSchemaKeyword
 	/// </param>
 	/// <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
 	/// <returns>A constraint object.</returns>
-	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, IReadOnlyList<KeywordConstraint> localConstraints, EvaluationContext context)
+	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
 		if (BoolValue.HasValue)
 		{
 			if (!BoolValue.Value) return KeywordConstraint.Skip;
 
-			var minimumConstraint = localConstraints.SingleOrDefault(x => x.Keyword == MinimumKeyword.Name);
+			var minimumConstraint = localConstraints.GetKeywordConstraint<MinimumKeyword>();
 			if (minimumConstraint == null) return KeywordConstraint.Skip;
 
 			var value = schemaConstraint.LocalSchema.GetMinimum()!.Value;

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Json.More;
 using Json.Schema;
+using Vocabularies = Json.Schema.OpenApi.Vocabularies;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -11,6 +12,7 @@ namespace Graeae.Models.SchemaDraft4;
 [SchemaKeyword(Name)]
 [SchemaSpecVersion(Draft4Support.Draft4Version)]
 [SchemaSpecVersion(SpecVersion.Draft202012)]
+[Vocabulary(Vocabularies.OpenApiId)]
 [JsonConverter(typeof(Draft4ExclusiveMinimumKeywordJsonConverter))]
 public class Draft4ExclusiveMinimumKeyword : IJsonSchemaKeyword
 {

--- a/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4ExclusiveMinimumKeyword.cs
@@ -88,7 +88,9 @@ public class Draft4ExclusiveMinimumKeyword : IJsonSchemaKeyword
 		var number = evaluation.LocalInstance!.AsValue().GetNumber();
 
 		if (number >= limit)
-			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMinimum(context.Options.Culture), ("received", number), ("limit", BoolValue));
+			evaluation.Results.Fail(Name, ErrorMessages.GetExclusiveMinimum(context.Options.Culture)
+				.ReplaceToken("received", number)
+				.ReplaceToken("limit", BoolValue));
 	}
 }
 

--- a/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Json.More;
 using Json.Schema;
+using Vocabularies = Json.Schema.OpenApi.Vocabularies;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -10,6 +11,7 @@ namespace Graeae.Models.SchemaDraft4;
 /// </summary>
 [SchemaKeyword(Name)]
 [SchemaSpecVersion(Draft4Support.Draft4Version)]
+[Vocabulary(Vocabularies.OpenApiId)]
 [JsonConverter(typeof(Draft4IdKeywordJsonConverter))]
 public class Draft4IdKeyword : IIdKeyword
 {

--- a/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using Json.More;
 using Json.Schema;
 
 namespace Graeae.Models.SchemaDraft4;
@@ -45,7 +46,7 @@ public class Draft4IdKeyword : IIdKeyword
 	}
 }
 
-internal class Draft4IdKeywordJsonConverter : JsonConverter<Draft4IdKeyword>
+internal class Draft4IdKeywordJsonConverter : WeaklyTypedJsonConverter<Draft4IdKeyword>
 {
 	public override Draft4IdKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{

--- a/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4IdKeyword.cs
@@ -39,7 +39,7 @@ public class Draft4IdKeyword : IIdKeyword
 	/// </param>
 	/// <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
 	/// <returns>A constraint object.</returns>
-	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, IReadOnlyList<KeywordConstraint> localConstraints, EvaluationContext context)
+	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
 		return KeywordConstraint.Skip;
 	}

--- a/Graeae.Models/SchemaDraft4/Draft4SchemaSerializerContext.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4SchemaSerializerContext.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Json.Schema;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -7,4 +8,5 @@ namespace Graeae.Models.SchemaDraft4;
 [JsonSerializable(typeof(Draft4IdKeyword))]
 [JsonSerializable(typeof(Draft4TypeKeyword))]
 [JsonSerializable(typeof(NullableKeyword))]
+[JsonSerializable(typeof(SchemaValueType))]
 internal partial class Draft4SchemaSerializerContext : JsonSerializerContext;

--- a/Graeae.Models/SchemaDraft4/Draft4SchemaSerializerContext.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4SchemaSerializerContext.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Graeae.Models.SchemaDraft4;
+
+[JsonSerializable(typeof(Draft4ExclusiveMaximumKeyword))]
+[JsonSerializable(typeof(Draft4ExclusiveMinimumKeyword))]
+[JsonSerializable(typeof(Draft4IdKeyword))]
+[JsonSerializable(typeof(Draft4TypeKeyword))]
+[JsonSerializable(typeof(NullableKeyword))]
+internal partial class Draft4SchemaSerializerContext : JsonSerializerContext;

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -167,10 +167,6 @@ public static class Draft4Support
 			.Build();
 
 		draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
-		// This is a hack to set the schema.DeclaredVersion property.
-		// It allows draft 4 to be used as a meta-schema.
-		// It's a bit of a hidden feature of JsonSchema.Net.
-		draft4MetaSchema.Evaluate(new JsonObject(), new EvaluationOptions { EvaluateAs = Draft4Version });
 		return draft4MetaSchema;
 	}
 
@@ -185,6 +181,10 @@ public static class Draft4Support
 		SchemaKeywordRegistry.Register<NullableKeyword>();
 		SchemaKeywordRegistry.Register<Draft4TypeKeyword>();
 
-		SchemaRegistry.Global.Register(Draft4MetaSchema);
+		SchemaRegistry.RegisterNewSpecVersion(Draft4MetaSchema.BaseUri, Draft4Version);
+		// This is a hack to set the schema.DeclaredVersion property.
+		// It allows draft 4 to be used as a meta-schema.
+		// It's a bit of a hidden feature of JsonSchema.Net.
+		Draft4MetaSchema.Evaluate(new JsonObject(), new EvaluationOptions { EvaluateAs = Draft4Version });
 	}
 }

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -28,8 +28,12 @@ public static class Draft4Support
 	/// <summary>
 	/// Defines the JSON Schema draft 4 meta-schema.
 	/// </summary>
-	public static readonly JsonSchema Draft4MetaSchema =
-		new JsonSchemaBuilder()
+	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema.Value;
+	private static readonly Lazy<JsonSchema> _draft4MetaSchema = new Lazy<JsonSchema>(InitializeDraft4Schema);
+
+	private static JsonSchema InitializeDraft4Schema()
+	{
+		var draft4MetaSchema = new JsonSchemaBuilder()
 			.OasId(Draft4MetaSchemaUri)
 			.Schema(Draft4MetaSchemaUri)
 			.Description("Core schema meta-schema")
@@ -159,15 +163,15 @@ public static class Draft4Support
 				("exclusiveMaximum", new [] { "maximum" }),
 				("exclusiveMinimum", new [] { "minimum" })
 			)
-			.Default(new JsonObject());
+			.Default(new JsonObject())
+			.Build();
 
-	static Draft4Support()
-	{
-		Draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
+		draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
 		// This is a hack to set the schema.DeclaredVersion property.
 		// It allows draft 4 to be used as a meta-schema.
 		// It's a bit of a hidden feature of JsonSchema.Net.
-		Draft4MetaSchema.Evaluate(new JsonObject(), new EvaluationOptions { EvaluateAs = Draft4Version });
+		draft4MetaSchema.Evaluate(new JsonObject(), new EvaluationOptions { EvaluateAs = Draft4Version });
+		return draft4MetaSchema;
 	}
 
 	/// <summary>

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -175,11 +175,11 @@ public static class Draft4Support
 	/// </summary>
 	public static void Enable()
 	{
-		SchemaKeywordRegistry.Register<Draft4ExclusiveMaximumKeyword>();
-		SchemaKeywordRegistry.Register<Draft4ExclusiveMinimumKeyword>();
-		SchemaKeywordRegistry.Register<Draft4IdKeyword>();
-		SchemaKeywordRegistry.Register<NullableKeyword>();
-		SchemaKeywordRegistry.Register<Draft4TypeKeyword>();
+		SchemaKeywordRegistry.Register<Draft4ExclusiveMaximumKeyword>(Draft4SchemaSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4ExclusiveMinimumKeyword>(Draft4SchemaSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4IdKeyword>(Draft4SchemaSerializerContext.Default);
+		SchemaKeywordRegistry.Register<NullableKeyword>(Draft4SchemaSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4TypeKeyword>(Draft4SchemaSerializerContext.Default);
 
 		SchemaRegistry.RegisterNewSpecVersion(Draft4MetaSchema.BaseUri, Draft4Version);
 		// This is a hack to set the schema.DeclaredVersion property.

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -167,6 +167,7 @@ public static class Draft4Support
 			.Build();
 
 		draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
+		SchemaRegistry.RegisterNewSpecVersion(draft4MetaSchema.BaseUri, Draft4Version);
 		return draft4MetaSchema;
 	}
 
@@ -181,10 +182,6 @@ public static class Draft4Support
 		SchemaKeywordRegistry.Register<NullableKeyword>(Draft4SchemaSerializerContext.Default);
 		SchemaKeywordRegistry.Register<Draft4TypeKeyword>(Draft4SchemaSerializerContext.Default);
 
-		SchemaRegistry.RegisterNewSpecVersion(Draft4MetaSchema.BaseUri, Draft4Version);
-		// This is a hack to set the schema.DeclaredVersion property.
-		// It allows draft 4 to be used as a meta-schema.
-		// It's a bit of a hidden feature of JsonSchema.Net.
-		Draft4MetaSchema.Evaluate(new JsonObject(), new EvaluationOptions { EvaluateAs = Draft4Version });
+		SchemaRegistry.Global.Register(Draft4MetaSchema);
 	}
 }

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -33,7 +33,7 @@ public static class Draft4Support
 
 	private static JsonSchema InitializeDraft4Schema()
 	{
-		var draft4MetaSchema = new JsonSchemaBuilder()
+		JsonSchema draft4MetaSchema = new JsonSchemaBuilder()
 			.OasId(Draft4MetaSchemaUri)
 			.Schema(Draft4MetaSchemaUri)
 			.Description("Core schema meta-schema")
@@ -163,8 +163,7 @@ public static class Draft4Support
 				("exclusiveMaximum", new [] { "maximum" }),
 				("exclusiveMinimum", new [] { "minimum" })
 			)
-			.Default(new JsonObject())
-			.Build();
+			.Default(new JsonObject());
 
 		draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
 		SchemaRegistry.RegisterNewSpecVersion(draft4MetaSchema.BaseUri, Draft4Version);

--- a/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
@@ -57,13 +57,13 @@ internal class Draft4TypeKeywordConverter : WeaklyTypedJsonConverter<Draft4TypeK
 {
 	public override Draft4TypeKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		var type = JsonSerializer.Deserialize<SchemaValueType>(ref reader, options);
+		var type = options.Read(ref reader, Draft4SchemaSerializerContext.Default.SchemaValueType);
 
 		return new Draft4TypeKeyword(type);
 	}
+
 	public override void Write(Utf8JsonWriter writer, Draft4TypeKeyword value, JsonSerializerOptions options)
 	{
-		writer.WritePropertyName(Draft4TypeKeyword.Name);
-		JsonSerializer.Serialize(writer, value.Type, options);
+		options.Write(writer, value.Type, Draft4SchemaSerializerContext.Default.SchemaValueType);
 	}
 }

--- a/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Json.More;
 using Json.Schema;
+using Vocabularies = Json.Schema.OpenApi.Vocabularies;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -11,6 +12,7 @@ namespace Graeae.Models.SchemaDraft4;
 [SchemaKeyword(Name)]
 [SchemaSpecVersion(Draft4Support.Draft4Version)]
 [SchemaSpecVersion(SpecVersion.Draft202012)]
+[Vocabulary(Vocabularies.OpenApiId)]
 [JsonConverter(typeof(Draft4TypeKeywordConverter))]
 public class Draft4TypeKeyword : IJsonSchemaKeyword
 {

--- a/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using Json.More;
 using Json.Schema;
 
 namespace Graeae.Models.SchemaDraft4;
@@ -52,7 +53,7 @@ public class Draft4TypeKeyword : IJsonSchemaKeyword
 	}
 }
 
-internal class Draft4TypeKeywordConverter : JsonConverter<Draft4TypeKeyword>
+internal class Draft4TypeKeywordConverter : WeaklyTypedJsonConverter<Draft4TypeKeyword>
 {
 	public override Draft4TypeKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{

--- a/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4TypeKeyword.cs
@@ -44,7 +44,7 @@ public class Draft4TypeKeyword : IJsonSchemaKeyword
 	/// </param>
 	/// <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
 	/// <returns>A constraint object.</returns>
-	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, IReadOnlyList<KeywordConstraint> localConstraints, EvaluationContext context)
+	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
 		return context.Options.EvaluateAs == Draft4Support.Draft4Version
 			? _draft4Support.GetConstraint(schemaConstraint, localConstraints, context)

--- a/Graeae.Models/SchemaDraft4/NullableKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/NullableKeyword.cs
@@ -2,6 +2,7 @@
 using System.Text.Json.Serialization;
 using Json.More;
 using Json.Schema;
+using Vocabularies = Json.Schema.OpenApi.Vocabularies;
 
 namespace Graeae.Models.SchemaDraft4;
 
@@ -10,6 +11,7 @@ namespace Graeae.Models.SchemaDraft4;
 /// </summary>
 [SchemaKeyword(Name)]
 [SchemaSpecVersion(Draft4Support.Draft4Version)]
+[Vocabulary(Vocabularies.OpenApiId)]
 [JsonConverter(typeof(NullableKeywordJsonConverter))]
 public class NullableKeyword : IJsonSchemaKeyword
 {

--- a/Graeae.Models/SchemaDraft4/NullableKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/NullableKeyword.cs
@@ -39,7 +39,7 @@ public class NullableKeyword : IJsonSchemaKeyword
 	/// </param>
 	/// <param name="context">The <see cref="T:Json.Schema.EvaluationContext" />.</param>
 	/// <returns>A constraint object.</returns>
-	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, IReadOnlyList<KeywordConstraint> localConstraints, EvaluationContext context)
+	public KeywordConstraint GetConstraint(SchemaConstraint schemaConstraint, ReadOnlySpan<KeywordConstraint> localConstraints, EvaluationContext context)
 	{
 		return new KeywordConstraint(Name, Evaluator);
 	}

--- a/Graeae.Models/SchemaDraft4/NullableKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/NullableKeyword.cs
@@ -70,6 +70,6 @@ internal class NullableKeywordJsonConverter : WeaklyTypedJsonConverter<NullableK
 
 	public override void Write(Utf8JsonWriter writer, NullableKeyword value, JsonSerializerOptions options)
 	{
-		writer.WriteBoolean(NullableKeyword.Name, value.Value);
+		writer.WriteBooleanValue(value.Value);
 	}
 }

--- a/Graeae.Models/SchemaDraft4/NullableKeyword.cs
+++ b/Graeae.Models/SchemaDraft4/NullableKeyword.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using Json.More;
 using Json.Schema;
 
 namespace Graeae.Models.SchemaDraft4;
@@ -53,7 +54,7 @@ public class NullableKeyword : IJsonSchemaKeyword
 	}
 }
 
-internal class NullableKeywordJsonConverter : JsonConverter<NullableKeyword>
+internal class NullableKeywordJsonConverter : WeaklyTypedJsonConverter<NullableKeyword>
 {
 	public override NullableKeyword Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{

--- a/Graeae.Models/SerializationExtensions.cs
+++ b/Graeae.Models/SerializationExtensions.cs
@@ -187,7 +187,7 @@ internal static class SerializationExtensions
 
 		foreach (var (key, value) in extensionData)
 		{
-			obj.Add(key, value.Copy());
+			obj.Add(key, value.DeepClone());
 		}
 	}
 

--- a/Graeae.Models/SerializationExtensions.cs
+++ b/Graeae.Models/SerializationExtensions.cs
@@ -187,7 +187,7 @@ internal static class SerializationExtensions
 
 		foreach (var (key, value) in extensionData)
 		{
-			obj.Add(key, value.DeepClone());
+			obj.Add(key, value?.DeepClone());
 		}
 	}
 


### PR DESCRIPTION
Update dependencies to use newest JsonSchema.Net

I tried following the pattern in JsonSchema repository for keyword changes, and also fixed anything that was causing build breaks:
- Json.More does not provide JsonNode.Copy any more -- replaced it with native JsonNode.DeepClone
- `JsonNull` was replaced by .net's `null`
- `JsonPointer` does not have `.Segments` property any more and itself is an enumerable of segments
- Use `WeaklyTypedJsonConverter` for all keywords, following the pattern in JsonSchema.Net
- Lazily initialize `Draft4MetaSchema` as keywords need to be registered before its initialization
- I am not entirely sure why `NullableKeywordJsonConverter` change was required, but without that it was serializing nullable as `"nullable": "nullable": true`