### PR TITLE
Allow calling Draft4Support.Enable() multiple times

### DIFF
--- a/Graeae.Models.Tests/ApiTests.cs
+++ b/Graeae.Models.Tests/ApiTests.cs
@@ -5,12 +5,8 @@ namespace Graeae.Models.Tests;
 public class ApiTests
 {
     [Test]
-    public void MultipleEnableDoesNotThrow()
+    public void InitializingAgainDoesNotThrow()
     {
-        Assert.DoesNotThrow(() =>
-        {
-            Draft4Support.Enable();
-            Draft4Support.Enable();
-        });
+        Draft4Support.Enable();
     }
 }

--- a/Graeae.Models.Tests/ApiTests.cs
+++ b/Graeae.Models.Tests/ApiTests.cs
@@ -1,0 +1,16 @@
+using Graeae.Models.SchemaDraft4;
+
+namespace Graeae.Models.Tests;
+
+public class ApiTests
+{
+    [Test]
+    public void MultipleEnableDoesNotThrow()
+    {
+        Assert.DoesNotThrow(() =>
+        {
+            Draft4Support.Enable();
+            Draft4Support.Enable();
+        });
+    }
+}

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -19,9 +19,9 @@
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../RELEASE_NOTES.md"))</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>Graeae.Models.xml</DocumentationFile>
-    <Version>0.3.1.2</Version>
-    <FileVersion>0.3.1.2</FileVersion>
-    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <Version>0.3.2</Version>
+    <FileVersion>0.3.2</FileVersion>
+    <AssemblyVersion>0.3.2.0</AssemblyVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/Graeae.Models/Graeae.Models.csproj
+++ b/Graeae.Models/Graeae.Models.csproj
@@ -19,8 +19,8 @@
     <PackageReleaseNotes>$([System.IO.File]::ReadAllText("$(MSBuildProjectDirectory)/../RELEASE_NOTES.md"))</PackageReleaseNotes>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <DocumentationFile>Graeae.Models.xml</DocumentationFile>
-    <Version>0.3.1.1</Version>
-    <FileVersion>0.3.1.1</FileVersion>
+    <Version>0.3.1.2</Version>
+    <FileVersion>0.3.1.2</FileVersion>
     <AssemblyVersion>0.3.0.0</AssemblyVersion>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/Graeae.Models/Graeae.Models.xml
+++ b/Graeae.Models/Graeae.Models.xml
@@ -1993,10 +1993,6 @@
             <summary>
             Defines the JSON Schema draft 4 meta-schema.
             </summary>
-            <remarks>
-            This property is initialized by the <see cref="M:Graeae.Models.SchemaDraft4.Draft4Support.Enable"/> method and
-            will be null if accessed before that method is called.
-            </remarks>
         </member>
         <member name="M:Graeae.Models.SchemaDraft4.Draft4Support.Enable">
             <summary>

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -8,6 +8,8 @@ namespace Graeae.Models.SchemaDraft4;
 /// </summary>
 public static class Draft4Support
 {
+	private static JsonSchema _draft4MetaSchema;
+
 	/// <summary>
 	/// Defines a JSON Schema draft 4 spec version.
 	/// </summary>
@@ -32,7 +34,6 @@ public static class Draft4Support
 	/// This property is initialized by the <see cref="Enable"/> method and
 	/// will be null if accessed before that method is called.
 	/// </remarks>
-	private static readonly JsonSchema _draft4MetaSchema; // move this to the top of the class
 	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema ??= InitializeDraf4MetaSchema();
 
 	private static JsonSchema InitializeDraft4Schema()

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -32,20 +32,12 @@ public static class Draft4Support
 	/// This property is initialized by the <see cref="Enable"/> method and
 	/// will be null if accessed before that method is called.
 	/// </remarks>
-	public static JsonSchema Draft4MetaSchema { get; private set; } = null!;
+	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema.Value;
+	private static readonly Lazy<JsonSchema> _draft4MetaSchema = new Lazy<JsonSchema>(InitializeDraft4Schema);
 
-	/// <summary>
-	/// Enables support for OpenAPI v3.0 and JSON Schema draft 4.
-	/// </summary>
-	public static void Enable()
+	private static JsonSchema InitializeDraft4Schema()
 	{
-		SchemaKeywordRegistry.Register<Draft4ExclusiveMaximumKeyword>(GraeaeSerializerContext.Default);
-		SchemaKeywordRegistry.Register<Draft4ExclusiveMinimumKeyword>(GraeaeSerializerContext.Default);
-		SchemaKeywordRegistry.Register<Draft4IdKeyword>(GraeaeSerializerContext.Default);
-		SchemaKeywordRegistry.Register<NullableKeyword>(GraeaeSerializerContext.Default);
-		SchemaKeywordRegistry.Register<Draft4TypeKeyword>(GraeaeSerializerContext.Default);
-
-		Draft4MetaSchema = new JsonSchemaBuilder()
+		JsonSchema draft4MetaSchema = new JsonSchemaBuilder()
 			.OasId(Draft4MetaSchemaUri)
 			.Schema(Draft4MetaSchemaUri)
 			.Description("Core schema meta-schema")
@@ -172,13 +164,27 @@ public static class Draft4Support
 				("not", JsonSchemaBuilder.RefRoot())
 			)
 			.Dependencies(
-				("exclusiveMaximum", new[] { "maximum" }),
-				("exclusiveMinimum", new[] { "minimum" })
+				("exclusiveMaximum", new [] { "maximum" }),
+				("exclusiveMinimum", new [] { "minimum" })
 			)
 			.Default(new JsonObject());
-		Draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
+
+		draft4MetaSchema.BaseUri = new Uri(Draft4MetaSchemaUri);
 		// This allows draft 4 to be used as a meta-schema.
-		SchemaRegistry.RegisterNewSpecVersion(Draft4MetaSchema.BaseUri, Draft4Version);
+		SchemaRegistry.RegisterNewSpecVersion(draft4MetaSchema.BaseUri, Draft4Version);
+		return draft4MetaSchema;
+	}
+
+	/// <summary>
+	/// Enables support for OpenAPI v3.0 and JSON Schema draft 4.
+	/// </summary>
+	public static void Enable()
+	{
+		SchemaKeywordRegistry.Register<Draft4ExclusiveMaximumKeyword>(GraeaeSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4ExclusiveMinimumKeyword>(GraeaeSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4IdKeyword>(GraeaeSerializerContext.Default);
+		SchemaKeywordRegistry.Register<NullableKeyword>(GraeaeSerializerContext.Default);
+		SchemaKeywordRegistry.Register<Draft4TypeKeyword>(GraeaeSerializerContext.Default);
 
 		SchemaRegistry.Global.Register(Draft4MetaSchema);
 	}

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -32,8 +32,8 @@ public static class Draft4Support
 	/// This property is initialized by the <see cref="Enable"/> method and
 	/// will be null if accessed before that method is called.
 	/// </remarks>
-	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema.Value;
-	private static readonly Lazy<JsonSchema> _draft4MetaSchema = new Lazy<JsonSchema>(InitializeDraft4Schema);
+	private static readonly JsonSchema _draft4MetaSchema; // move this to the top of the class
+	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema ??= InitializeDraf4MetaSchema();
 
 	private static JsonSchema InitializeDraft4Schema()
 	{

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -30,13 +30,9 @@ public static class Draft4Support
 	/// <summary>
 	/// Defines the JSON Schema draft 4 meta-schema.
 	/// </summary>
-	/// <remarks>
-	/// This property is initialized by the <see cref="Enable"/> method and
-	/// will be null if accessed before that method is called.
-	/// </remarks>
-	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema ??= InitializeDraf4MetaSchema();
+	public static JsonSchema Draft4MetaSchema => _draft4MetaSchema ??= InitializeDraft4MetaSchema();
 
-	private static JsonSchema InitializeDraft4Schema()
+	private static JsonSchema InitializeDraft4MetaSchema()
 	{
 		JsonSchema draft4MetaSchema = new JsonSchemaBuilder()
 			.OasId(Draft4MetaSchemaUri)

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -164,8 +164,8 @@ public static class Draft4Support
 				("not", JsonSchemaBuilder.RefRoot())
 			)
 			.Dependencies(
-				("exclusiveMaximum", new [] { "maximum" }),
-				("exclusiveMinimum", new [] { "minimum" })
+				("exclusiveMaximum", new[] { "maximum" }),
+				("exclusiveMinimum", new[] { "minimum" })
 			)
 			.Default(new JsonObject());
 

--- a/Graeae.Models/SchemaDraft4/Draft4Support.cs
+++ b/Graeae.Models/SchemaDraft4/Draft4Support.cs
@@ -8,7 +8,7 @@ namespace Graeae.Models.SchemaDraft4;
 /// </summary>
 public static class Draft4Support
 {
-	private static JsonSchema _draft4MetaSchema;
+	private static JsonSchema? _draft4MetaSchema;
 
 	/// <summary>
 	/// Defines a JSON Schema draft 4 spec version.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+[0.3.2](https://github.com/gregsdennis/Graeae/pull/11)
+
+- Fixed a bug that Draft4Support.Enable() crashed when called multiple times.
+
 [0.3.1](https://github.com/gregsdennis/Graeae/pull/10)
 
 _v0.3.1.1 is a re-publish to include these release notes._


### PR DESCRIPTION
Second call to `Draft4Support.Enable()` was throwing

```console
  Failed MultipleEnableDoesNotThrow [36 ms]
  Error Message:
   System.ArgumentException : Overriding known specification versions is not supported.
  Stack Trace:
     at Json.Schema.SchemaRegistry.RegisterNewSpecVersion(Uri metaSchemaUri, SpecVersion specVersion)
   at Graeae.Models.SchemaDraft4.Draft4Support.Enable() in D:\src\Graeae\Graeae.Models\SchemaDraft4\Draft4Support.cs:line 181
   at Graeae.Models.Tests.ApiTests.MultipleEnableDoesNotThrow() in D:\src\Graeae\Graeae.Models.Tests\ApiTests.cs:line 10
```